### PR TITLE
[AOC2024] Add some common queue implementations (anticipated use)

### DIFF
--- a/aoc2024/internal/queue/fifo.go
+++ b/aoc2024/internal/queue/fifo.go
@@ -1,0 +1,58 @@
+package queue
+
+type Fifo[T any] struct {
+	data  []T
+	first int
+	last  int
+}
+
+func NewFifo[T any]() Fifo[T] {
+	return NewFifoWithCapacity[T](100)
+}
+
+func NewFifoWithCapacity[T any](capacity int) Fifo[T] {
+	return Fifo[T]{
+		data:  make([]T, capacity),
+		first: 0,
+		last:  0,
+	}
+}
+
+func (self *Fifo[T]) Push(x T) {
+	if self.Len() == len(self.data) {
+		self.reallocate(2 * len(self.data))
+	}
+
+	self.data[self.last] = x
+	self.last += 1
+}
+
+func (self *Fifo[T]) Pop() (T, bool) {
+	var ret T
+	if self.Len() == 0 {
+		return ret, false
+	}
+
+	ret = self.data[self.first]
+	self.first = (self.first + 1) % len(self.data)
+	return ret, true
+}
+
+func (self *Fifo[T]) Len() int {
+	if self.first > self.last {
+		return len(self.data) - (self.first - self.last)
+	}
+
+	return self.last - self.first
+}
+
+func (self *Fifo[T]) reallocate(newCapacity int) {
+	oldLen := self.Len()
+	newData := make([]T, newCapacity)
+	for i := 0; i < oldLen; i += 1 {
+		newData[i] = self.data[(self.first+i)%oldLen]
+	}
+	self.data = newData
+	self.first = 0
+	self.last = oldLen
+}

--- a/aoc2024/internal/queue/fifo_test.go
+++ b/aoc2024/internal/queue/fifo_test.go
@@ -1,0 +1,55 @@
+package queue
+
+import (
+	"testing"
+)
+
+func TestFifoRemovesItemsInInsertionOrder(t *testing.T) {
+	fifo := NewFifo[int]()
+
+	for i := range 5 {
+		fifo.Push(i)
+	}
+
+	for i := range 5 {
+		x, ok := fifo.Pop()
+
+		if !ok {
+			t.Errorf("Expected pop of %d to be successful (ok)", i)
+		}
+
+		if x != i {
+			t.Errorf("Expected the %dth pop to produce %d; got %d", i, i, x)
+		}
+	}
+}
+
+func TestFifoWithReallocationRemovesItemsInInsertionOrder(t *testing.T) {
+	fifo := NewFifoWithCapacity[int](3)
+
+	for i := range 5 {
+		fifo.Push(i)
+	}
+
+	for i := range 5 {
+		x, ok := fifo.Pop()
+
+		if !ok {
+			t.Errorf("Expected pop of %d to be successful (ok)", i)
+		}
+
+		if x != i {
+			t.Errorf("Expected the %dth pop to produce %d; got %d", i, i, x)
+		}
+	}
+}
+
+func TestFifoEmptyPopReturnsFalse(t *testing.T) {
+	fifo := NewFifo[int]()
+
+	_, ok := fifo.Pop()
+
+	if ok {
+		t.Errorf("Expected pop from empty queue to produce zero value and false; got %v", ok)
+	}
+}

--- a/aoc2024/internal/queue/lifo.go
+++ b/aoc2024/internal/queue/lifo.go
@@ -1,0 +1,34 @@
+package queue
+
+type Lifo[T any] struct {
+	data []T
+}
+
+func NewLifo[T any]() Lifo[T] {
+	return NewLifoWithCapacity[T](100)
+}
+
+func NewLifoWithCapacity[T any](capacity int) Lifo[T] {
+	return Lifo[T]{
+		data: make([]T, 0, capacity),
+	}
+}
+
+func (self *Lifo[T]) Push(x T) {
+	self.data = append(self.data, x)
+}
+
+func (self *Lifo[T]) Pop() (T, bool) {
+	var ret T
+	if self.Len() == 0 {
+		return ret, false
+	}
+
+	ret = self.data[len(self.data)-1]
+	self.data = self.data[:len(self.data)-1]
+	return ret, true
+}
+
+func (self *Lifo[T]) Len() int {
+	return len(self.data)
+}

--- a/aoc2024/internal/queue/lifo_test.go
+++ b/aoc2024/internal/queue/lifo_test.go
@@ -1,0 +1,35 @@
+package queue
+
+import (
+	"testing"
+)
+
+func TestLifoRemovesItemsInReverseInsertionOrder(t *testing.T) {
+	lifo := NewLifo[int]()
+
+	for i := range 5 {
+		lifo.Push(i)
+	}
+
+	for i := range 5 {
+		x, ok := lifo.Pop()
+
+		if !ok {
+			t.Errorf("Expected pop of %d to be successful (ok)", i)
+		}
+
+		if x != 5-(i+1) {
+			t.Errorf("Expected the %dth pop to produce %d; got %d", i, 5-(i+1), x)
+		}
+	}
+}
+
+func TestLifoEmptyPopReturnsFalse(t *testing.T) {
+	lifo := NewLifo[int]()
+
+	_, ok := lifo.Pop()
+
+	if ok {
+		t.Errorf("Expected pop from empty queue to produce zero value and false; got %v", ok)
+	}
+}

--- a/aoc2024/internal/queue/priority.go
+++ b/aoc2024/internal/queue/priority.go
@@ -1,0 +1,69 @@
+package queue
+
+import (
+	"container/heap"
+)
+
+type Priority[T any] struct {
+	internal internalHeap[T]
+}
+
+func NewPriority[T comparable](cmp func(T, T) bool) Priority[T] {
+	return NewPriorityWithCapacity[T](cmp, 100)
+}
+
+func NewPriorityWithCapacity[T comparable](cmp func(T, T) bool, capacity int) Priority[T] {
+	return Priority[T]{
+		internal: internalHeap[T]{
+			data: make([]T, 0, capacity),
+			cmp:  cmp,
+		},
+	}
+}
+
+func (self *Priority[T]) Push(x T) {
+	heap.Push(&self.internal, x)
+}
+
+func (self *Priority[T]) Pop() (T, bool) {
+	var ret T
+	if self.Len() == 0 {
+		return ret, false
+	}
+
+	ret = heap.Pop(&self.internal).(T)
+	return ret, true
+}
+
+func (self *Priority[T]) Len() int {
+	return self.internal.Len()
+}
+
+type internalHeap[T any] struct {
+	data []T
+	cmp  func(T, T) bool
+}
+
+func (self internalHeap[T]) Len() int {
+	return len(self.data)
+}
+
+func (self internalHeap[T]) Less(i int, j int) bool {
+	return self.cmp(self.data[i], self.data[j])
+}
+
+func (self internalHeap[T]) Swap(i int, j int) {
+	self.data[i], self.data[j] = self.data[j], self.data[i]
+}
+
+func (self *internalHeap[T]) Push(x any) {
+	self.data = append(self.data, x.(T))
+}
+
+func (self *internalHeap[T]) Pop() any {
+	old := self.data
+	n := len(old)
+	x := old[n-1]
+	self.data = old[:n-1]
+	return x
+}

--- a/aoc2024/internal/queue/priority_test.go
+++ b/aoc2024/internal/queue/priority_test.go
@@ -1,0 +1,60 @@
+package queue
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestPriorityPopsItemsInSortedOrder(t *testing.T) {
+	type Item struct {
+		priority int
+		value    string
+	}
+
+	items := []Item{
+		{
+			priority: 2,
+			value:    "two",
+		},
+		{
+			priority: 3,
+			value:    "three",
+		},
+		{
+			priority: 1,
+			value:    "one",
+		},
+	}
+
+	priority := NewPriority(func(a Item, b Item) bool { return a.priority < b.priority })
+
+	for _, item := range items {
+		priority.Push(item)
+	}
+
+	slices.SortFunc(items, func(a Item, b Item) int {
+		return a.priority - b.priority
+	})
+
+	for i, expectedItem := range items {
+		item, ok := priority.Pop()
+
+		if !ok {
+			t.Errorf("Expected popping item %d to be ok; got %v", i, ok)
+		}
+
+		if item.priority != expectedItem.priority || item.value != expectedItem.value {
+			t.Errorf("Expected popped item %d would be %v; got %v", i, expectedItem, item)
+		}
+	}
+}
+
+func TestEmptyPriorityPopReturnsZeroValueAndFalse(t *testing.T) {
+	priority := NewPriority(func(a int, b int) bool { return a < b })
+
+	_, ok := priority.Pop()
+
+	if ok {
+		t.Errorf("Expected pop from empty queue to return zero value and false; got %v", ok)
+	}
+}


### PR DESCRIPTION
- Add a queue (FIFO) implementation for (anticipated) convenience
- Add a stack (LIFO) implementation for (anticipated) convenience
- Add a priority queue implementation for (anticipated) convenience