### PR TITLE
[AOC2024] Don't show usage on handleable error

### DIFF
--- a/aoc2024/internal/solution/solution.go
+++ b/aoc2024/internal/solution/solution.go
@@ -112,12 +112,13 @@ func Run(inputPath string, day int, part int) error {
 	solveDuration := stopTime.Sub(startTime)
 
 	if err != nil {
-		return fmt.Errorf(
-			"unable to solve %d.%d, errored after %dµs: %w",
+		fmt.Printf(
+			"unable to solve %d.%d, errored after %dµs: %+v\n",
 			day,
 			part,
 			solveDuration.Microseconds(),
 			err)
+		return nil
 	}
 
 	fmt.Printf("%s\n", result)


### PR DESCRIPTION
- Return nil on error from the problem solution, as it is "handleable"; rather print the error message _without_ the usage information